### PR TITLE
Add Manga page and mobile drawer

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,9 @@
     "styled-components": "^5.3.6",
     "swiper": "^9.2.0",
     "web-vitals": "^2.1.4",
-    "@mui/material": "^5.15.0",
-    "@mui/icons-material": "^5.15.0",
     "@radix-ui/react-accordion": "^1.0.1",
-    "@radix-ui/react-icons": "^1.3.0"
+    "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-dialog": "^1.0.0"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import About from './pages/About';
+import Manga from './pages/Manga';
 import Footer from './components/Footer';
 import Navbar from './components/Navbar';
 import PeriGame from './pages/PeriGame';
@@ -15,6 +16,7 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/about" element={<About />} />
           <Route path="/game" element={<PeriGame />} />
+          <Route path="/manga" element={<Manga />} />
         </Routes>
       </main>
 

--- a/src/components/HowToBuy.js
+++ b/src/components/HowToBuy.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as Accordion from '@radix-ui/react-accordion';
-import { CheckCircle } from '@mui/icons-material';
+import { CheckIcon } from '@radix-ui/react-icons';
 import '../styles/HowToBuy.css';
 import { useTranslation } from 'react-i18next';
 
@@ -21,7 +21,7 @@ const HowToBuy = () => {
           <Accordion.Item value={`step-${index}`} key={index} className="step-item">
             <Accordion.Header>
               <Accordion.Trigger className="step-trigger">
-                <CheckCircle className="icon" />
+                <CheckIcon className="icon" />
                 {step}
               </Accordion.Trigger>
             </Accordion.Header>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -4,18 +4,17 @@ import logo from '../images/logo.svg';
 import '../styles/Navbar.css';
 import { useTranslation } from 'react-i18next';
 import i18n from 'i18next';
+import * as Dialog from '@radix-ui/react-dialog';
+import { HamburgerMenuIcon } from '@radix-ui/react-icons';
 
 const Navbar = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [open, setOpen] = useState(false);
   const { t } = useTranslation();
 
   const changeLanguage = (lng) => {
     i18n.changeLanguage(lng);
   };
 
-  const toggleMenu = () => {
-    setIsOpen(!isOpen);
-  };
 
   return (
     <nav className="navbar">
@@ -29,20 +28,33 @@ const Navbar = () => {
         <button onClick={() => changeLanguage('es')} className="language-button">Español</button>
       </div>
 
-      <button className="burger-button" onClick={toggleMenu}>
-        <span className="burger-bar"></span>
-        <span className="burger-bar"></span>
-        <span className="burger-bar"></span>
-      </button>
-      
-      <div className={`navbar-links ${isOpen ? 'open' : ''}`}>
+      <div className="navbar-links desktop-links">
         <ul>
-          <li><Link to="/" onClick={() => setIsOpen(false)}>{t('home')}</Link></li>
-          <li><Link to="/about" onClick={() => setIsOpen(false)}>{t('about')}</Link></li>
-          <li><Link to="/" onClick={() => setIsOpen(false)}>{t('merch')}</Link></li>
-          <li><Link to="/game" onClick={() => setIsOpen(false)}>{t('game')}</Link></li>
+          <li><Link to="/" >{t('home')}</Link></li>
+          <li><Link to="/about" >{t('about')}</Link></li>
+          <li><Link to="/manga" >{t('manga')}</Link></li>
+          <li><Link to="/game" >{t('game')}</Link></li>
         </ul>
       </div>
+
+      <Dialog.Root open={open} onOpenChange={setOpen}>
+        <Dialog.Trigger asChild>
+          <button className="burger-button">
+            <HamburgerMenuIcon />
+          </button>
+        </Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Overlay className="drawer-overlay" />
+          <Dialog.Content className="drawer-content">
+            <ul>
+              <li><Link to="/" onClick={() => setOpen(false)}>{t('home')}</Link></li>
+              <li><Link to="/about" onClick={() => setOpen(false)}>{t('about')}</Link></li>
+              <li><Link to="/manga" onClick={() => setOpen(false)}>{t('manga')}</Link></li>
+              <li><Link to="/game" onClick={() => setOpen(false)}>{t('game')}</Link></li>
+            </ul>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </nav>
   );
 };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -30,5 +30,6 @@
     "score": "Score:",
     "contractv2": "Contract",
     "contractcopied": "Contract address copied!",
-    "priceChart": "Price Chart"
+    "priceChart": "Price Chart",
+    "manga": "Manga"
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -30,5 +30,6 @@
     "score": "Puntuación:",
     "contractv2": "Contrato",
     "contractcopied": "¡Dirección del contrato copiada!",
-    "priceChart": "Gráfico de Precios"
+    "priceChart": "Gráfico de Precios",
+    "manga": "Manga"
 }

--- a/src/pages/Manga.js
+++ b/src/pages/Manga.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import '../styles/Manga.css';
+import { useTranslation } from 'react-i18next';
+
+const Manga = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="manga-page">
+      <h2>{t('manga')}</h2>
+      <ul className="manga-list">
+        <li>Perico Adventures - Chapter 5 releasing soon!</li>
+        <li>Crypto Feathers - New arc drops next week!</li>
+        <li>The Blockchain Bird - Volume 2 on the way!</li>
+      </ul>
+    </div>
+  );
+};
+
+export default Manga;

--- a/src/pages/Manga.test.js
+++ b/src/pages/Manga.test.js
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Manga from './Manga';
+import '../i18n';
+
+test('renders manga heading', () => {
+  render(<Manga />);
+  const heading = screen.getByRole('heading', { name: /manga/i });
+  expect(heading).toBeInTheDocument();
+});

--- a/src/styles/Manga.css
+++ b/src/styles/Manga.css
@@ -1,0 +1,8 @@
+.manga-page {
+  padding: 20px;
+}
+
+.manga-list {
+  list-style: disc;
+  margin-left: 20px;
+}

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -39,6 +39,11 @@
     gap: 20px;
 }
 
+.desktop-links {
+    display: flex;
+    gap: 20px;
+}
+
 .navbar-links ul {
     list-style: none;
     padding: 0;
@@ -64,12 +69,6 @@
     z-index: 10;
 }
 
-.burger-button .burger-bar {
-    width: 100%;
-    height: 3px;
-    background-color: black;
-    border-radius: 5px;
-}
 
 @media (max-width: 768px) {
     .navbar {
@@ -82,30 +81,36 @@
         display: flex;
     }
 
-    .navbar-links {
-        position: absolute;
-        top: 60px;
-        right: 0px;
-        background-color: #ae6d06;
-        flex-direction: column;
-        align-items: center;
-        gap: 10px;
-        padding: 10px 0;
+    .desktop-links {
         display: none;
-        z-index: 9;
     }
+}
 
-    .navbar-links.open {
-        display: flex;
-    }
+.drawer-overlay {
+    background-color: rgba(0, 0, 0, 0.4);
+    position: fixed;
+    inset: 0;
+}
 
-    .navbar-links ul {
-        flex-direction: column;
-        gap: 10px;
-    }
+.drawer-content {
+    background-color: #ae6d06;
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 200px;
+    padding: 20px;
+}
 
-    .navbar-links ul li {
-        width: 100%;
-        text-align: center;
-    }
+.drawer-content ul {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.drawer-content a {
+    text-decoration: none;
+    color: black;
 }


### PR DESCRIPTION
## Summary
- remove Material UI dependency
- use Radix CheckIcon in HowToBuy
- create new Manga page with styling
- add Drawer based mobile nav using Radix dialog
- wire up Manga route and translation strings
- basic unit test for Manga page

## Testing
- `npm test -- --watchAll=false` *(fails: react-app-rewired not found)*
- `npm run build` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460c1aff58832a924dac84537feeec