### PR TITLE
Improve drawer z-index and manga info

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -31,5 +31,7 @@
     "contractv2": "Contract",
     "contractcopied": "Contract address copied!",
     "priceChart": "Price Chart",
-    "manga": "Manga"
+    "manga": "Manga",
+    "mangaComingSoon": "Manga coming soon!",
+    "mangaFomo": "Don't miss out on $PERI before the manga drops. Buy now to join the flock!"
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -31,5 +31,7 @@
     "contractv2": "Contrato",
     "contractcopied": "¡Dirección del contrato copiada!",
     "priceChart": "Gráfico de Precios",
-    "manga": "Manga"
+    "manga": "Manga",
+    "mangaComingSoon": "¡Manga próximamente!",
+    "mangaFomo": "No te quedes sin $PERI antes del lanzamiento del manga. ¡Compra ahora y únete al vuelo!"
 }

--- a/src/pages/Manga.js
+++ b/src/pages/Manga.js
@@ -1,17 +1,30 @@
 import React from 'react';
 import '../styles/Manga.css';
 import { useTranslation } from 'react-i18next';
+import * as Accordion from '@radix-ui/react-accordion';
 
 const Manga = () => {
   const { t } = useTranslation();
+  const items = [
+    'Perico Adventures - Chapter 5 releasing soon!',
+    'Crypto Feathers - New arc drops next week!',
+    'The Blockchain Bird - Volume 2 on the way!',
+  ];
+
   return (
     <div className="manga-page">
       <h2>{t('manga')}</h2>
-      <ul className="manga-list">
-        <li>Perico Adventures - Chapter 5 releasing soon!</li>
-        <li>Crypto Feathers - New arc drops next week!</li>
-        <li>The Blockchain Bird - Volume 2 on the way!</li>
-      </ul>
+      <Accordion.Root type="single" collapsible className="manga-list">
+        {items.map((item, index) => (
+          <Accordion.Item value={`item-${index}`} key={index} className="manga-item">
+            <Accordion.Header>
+              <Accordion.Trigger className="manga-trigger">{item}</Accordion.Trigger>
+            </Accordion.Header>
+            <Accordion.Content className="manga-content">{t('mangaComingSoon')}</Accordion.Content>
+          </Accordion.Item>
+        ))}
+      </Accordion.Root>
+      <p className="fomo">{t('mangaFomo')}</p>
     </div>
   );
 };

--- a/src/styles/Footer.css
+++ b/src/styles/Footer.css
@@ -14,12 +14,19 @@
     color: black;
   }
   
-  .footer-links {
+.footer-links {
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-top: 10px;
+}
+
+@media (max-width: 768px) {
+  .footer-links {
+    flex-direction: column;
+    gap: 10px;
   }
+}
   
   .footer-links .contract,
   .footer-links .contact {

--- a/src/styles/Manga.css
+++ b/src/styles/Manga.css
@@ -3,6 +3,32 @@
 }
 
 .manga-list {
-  list-style: disc;
-  margin-left: 20px;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.manga-item {
+  margin-bottom: 4px;
+}
+
+.manga-trigger {
+  all: unset;
+  display: block;
+  padding: 8px;
+  background-color: #f0f0f0;
+  cursor: pointer;
+}
+
+.manga-content {
+  padding: 8px 16px;
+  border: 1px solid #e2e2e2;
+  margin-bottom: 4px;
+}
+
+.fomo {
+  margin-top: 20px;
+  font-weight: bold;
+  color: #ae6d06;
+  text-align: center;
 }

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -5,7 +5,9 @@
     padding: 10px 20px;
     border-bottom: 1px solid #ccc;
     background-color: #ae6d06;
-    position: relative;
+    position: sticky;
+    top: 0;
+    z-index: 1000;
 }
 
 .navbar-logo img {
@@ -90,6 +92,7 @@
     background-color: rgba(0, 0, 0, 0.4);
     position: fixed;
     inset: 0;
+    z-index: 1001;
 }
 
 .drawer-content {
@@ -100,6 +103,7 @@
     height: 100%;
     width: 200px;
     padding: 20px;
+    z-index: 1002;
 }
 
 .drawer-content ul {


### PR DESCRIPTION
## Summary
- fix drawer stacking so menu stays on top
- make navbar sticky and mobile footer responsive
- restyle manga page using Radix accordion
- add FOMO text and translations

## Testing
- `npm test --silent --maxWorkers=50` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460f870b94832ab1b969a9b2b804c8