### PR TITLE
Refine manga mint page

### DIFF
--- a/src/pages/Manga.js
+++ b/src/pages/Manga.js
@@ -1,18 +1,13 @@
 import React from 'react';
 import '../styles/Manga.css';
 import { useTranslation } from 'react-i18next';
-import * as Accordion from '@radix-ui/react-accordion';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Button from '@mui/material/Button';
 
 const Manga = () => {
   const { t } = useTranslation();
-  const items = [
-    'Perico Adventures - Chapter 5 releasing soon!',
-    'Crypto Feathers - New arc drops next week!',
-    'The Blockchain Bird - Volume 2 on the way!',
-  ];
+  // Future chapter announcements will appear here
 
   return (
     <div className="manga-page">
@@ -23,17 +18,7 @@ const Manga = () => {
           <Button variant="contained" className="mint-btn">{t('mint')}</Button>
         </CardContent>
       </Card>
-      <Accordion.Root type="single" collapsible className="manga-list">
-        {items.map((item, index) => (
-          <Accordion.Item value={`item-${index}`} key={index} className="manga-item">
-            <Accordion.Header>
-              <Accordion.Trigger className="manga-trigger">{item}</Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Content className="manga-content">{t('mangaComingSoon')}</Accordion.Content>
-          </Accordion.Item>
-        ))}
-      </Accordion.Root>
-      <p className="fomo">{t('mangaFomo')}</p>
+      <div className="manga-coming-soon">{t('mangaComingSoon')}</div>
     </div>
   );
 };

--- a/src/styles/Manga.css
+++ b/src/styles/Manga.css
@@ -1,47 +1,34 @@
+
 .manga-page {
   padding: 20px;
+  text-align: center;
+  font-family: 'Comic Sans MS', 'Comic Neue', cursive;
 }
 
 .mint-card {
   text-align: center;
   padding: 20px;
-  margin-bottom: 20px;
-  background-color: #ADD8E6;
+  margin: 20px auto;
+  max-width: 400px;
+  background-color: var(--sky-blue);
   border-radius: 8px;
+  border: 4px dotted var(--accent-brown);
+}
+
+.mint-title {
+  color: var(--accent-brown);
+  margin-bottom: 10px;
 }
 
 .mint-btn {
-  background-color: #ae6d06 !important;
+  background-color: var(--primary-green) !important;
   color: #fff !important;
 }
 
-.manga-list {
-  width: 100%;
-  max-width: 600px;
-  margin: 0 auto;
-}
 
-.manga-item {
-  margin-bottom: 4px;
-}
-
-.manga-trigger {
-  all: unset;
-  display: block;
-  padding: 8px;
-  background-color: #f0f0f0;
-  cursor: pointer;
-}
-
-.manga-content {
-  padding: 8px 16px;
-  border: 1px solid #e2e2e2;
-  margin-bottom: 4px;
-}
-
-.fomo {
-  margin-top: 20px;
-  font-weight: bold;
-  color: #ae6d06;
-  text-align: center;
+.manga-coming-soon {
+  margin-top: 30px;
+  font-size: 1.2rem;
+  color: var(--accent-brown);
+  text-shadow: 2px 2px var(--sky-blue);
 }


### PR DESCRIPTION
## Summary
- simplify Manga page and remove placeholder chapter announcements and FOMO text
- add comic‐style UI using root color variables

## Testing
- `npm test -- -u` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8e04ee8c832ab9a3541e24ecf742