### PR TITLE
Simplify About page content

### DIFF
--- a/src/components/Listings.js
+++ b/src/components/Listings.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import '../styles/Listings.css';
+import { useTranslation } from 'react-i18next';
+
+const Listings = () => {
+  const { t } = useTranslation();
+  return (
+    <Card className="listings-card">
+      <CardContent>
+        <Typography variant="h5" component="h2">
+          {t('cex')}
+        </Typography>
+        <Typography variant="body2" className="listings-text">
+          {t('upcoming')}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default Listings;

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -1,78 +1,52 @@
 import React from 'react';
-import teamMember from '../images/web3.jpg';
-import meme1 from '../images/meme1.jpg';
-import meme2 from '../images/meme2.png';
-import meme3 from '../images/meme3.png';
-import meme4 from '../images/meme4.png';
-import meme5 from '../images/meme5.png';
-import meme6 from '../images/meme6.png';
-import meme7 from '../images/meme7.png';
-import meme8 from '../images/meme8.png';
-import meme9 from '../images/meme9.png';
-import meme10 from '../images/meme10.png';
-import meme11 from '../images/meme11.jpg';
-import meme12 from '../images/meme12.jpg';
-import meme13 from '../images/meme13.jpg';
-import '../styles/Team.css';
-import '../styles/CEXListings.css';
-import '../styles/MemeGallery.css';
-import Tokenomics from '../components/Tokenomics';
 import MemeGenerator from '../components/MemeGenerator';
+import Tokenomics from '../components/Tokenomics';
+import Listings from '../components/Listings';
+import * as Accordion from '@radix-ui/react-accordion';
+import '../styles/About.css';
 import { useTranslation } from 'react-i18next';
 
-
 function About() {
-    const { t } = useTranslation();
+  const { t } = useTranslation();
 
-    return (
-        <div className="about-container">
+  return (
+    <div className="about-page">
+      <Accordion.Root type="single" collapsible className="about-accordion">
+        <Accordion.Item value="meme">
+          <Accordion.Header>
+            <Accordion.Trigger className="about-trigger">
+              {t('generatorTitle')}
+            </Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content className="about-content">
             <MemeGenerator />
+          </Accordion.Content>
+        </Accordion.Item>
 
-            {/* Tokenomics Section */}
-
+        <Accordion.Item value="tokenomics">
+          <Accordion.Header>
+            <Accordion.Trigger className="about-trigger">
+              {t('tokenomics')}
+            </Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content className="about-content">
             <Tokenomics />
+          </Accordion.Content>
+        </Accordion.Item>
 
-            {/* Team Section */}
-            <section className="team">
-                <h2>{t("team")}</h2>
-                <div className="team-member">
-                    <img src={teamMember} alt="CEO" />
-                    <div className="team-info">
-                        <a href="https://x.com/0x1Juangunner4" target="_blank" rel="noopener noreferrer" className="member-link">
-                            {t("member1")}
-                        </a>
-                    </div>
-                </div>
-            </section>
-
-            {/* CEX Listings Section */}
-            <section className="cex-listings">
-                <h2>{t("cex")}</h2>
-                <p>{t("upcoming")}</p>
-            </section>
-
-            {/* Meme Gallery Section */}
-            <section className="meme-gallery">
-                <h2>{t("memes")}</h2>
-                <div className="meme-images">
-                    <img src={meme1} alt="Meme 1" />
-                    <img src={meme2} alt="Meme 2" />
-                    <img src={meme3} alt="Meme 3" />
-                    <img src={meme4} alt="Meme 4" />
-                    <img src={meme5} alt="Meme 5" />
-                    <img src={meme6} alt="Meme 6" />
-                    <img src={meme7} alt="Meme 7" />
-                    <img src={meme8} alt="Meme 8" />
-                    <img src={meme9} alt="Meme 9" />
-                    <img src={meme10} alt="Meme 9" />
-                    <img src={meme11} alt="Meme 9" />
-                    <img src={meme12} alt="Meme 9" />
-                    <img src={meme13} alt="Meme 9" />
-                    {/* Add more meme images as needed */}
-                </div>
-            </section>
-        </div>
-    );
+        <Accordion.Item value="listings">
+          <Accordion.Header>
+            <Accordion.Trigger className="about-trigger">
+              {t('cex')}
+            </Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Content className="about-content">
+            <Listings />
+          </Accordion.Content>
+        </Accordion.Item>
+      </Accordion.Root>
+    </div>
+  );
 }
 
 export default About;

--- a/src/styles/About.css
+++ b/src/styles/About.css
@@ -1,0 +1,29 @@
+.about-page {
+  padding: 20px;
+}
+
+.about-accordion {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.about-trigger {
+  all: unset;
+  display: block;
+  padding: 10px;
+  margin-bottom: 4px;
+  background-color: var(--sky-blue);
+  color: var(--accent-brown);
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.about-content {
+  background-color: var(--sky-blue);
+  border: 1px solid var(--primary-green);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 12px;
+}

--- a/src/styles/Listings.css
+++ b/src/styles/Listings.css
@@ -1,0 +1,15 @@
+.listings-card {
+  background-color: var(--sky-blue);
+  padding: 20px;
+  margin: 20px 0;
+  text-align: center;
+  border-radius: 8px;
+}
+
+.listings-card h2 {
+  color: var(--accent-brown);
+}
+
+.listings-text {
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- add simple Listings component
- replace `About` page with Radix accordion and MUI sections
- style about and listings pages using root color variables

## Testing
- `npm test -- -u` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8ec2d058832a9bed45b792f33bc1