### PR TITLE
Update game icon

### DIFF
--- a/src/pages/PeriGame.js
+++ b/src/pages/PeriGame.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPersonDigging } from '@fortawesome/free-solid-svg-icons';
+import { faPeopleRoof } from '@fortawesome/free-solid-svg-icons';
 import '../styles/PeriGame.css';
 import { useTranslation } from 'react-i18next';
 import Typography from '@mui/material/Typography';
@@ -9,7 +9,7 @@ const PeriGame = () => {
   const { t } = useTranslation();
   return (
     <div className="game-construction">
-      <FontAwesomeIcon icon={faPersonDigging} className="construction-icon" />
+      <FontAwesomeIcon icon={faPeopleRoof} className="construction-icon" />
       <Typography variant="h5">{t('underConstruction')}</Typography>
     </div>
   );

--- a/src/styles/PeriGame.css
+++ b/src/styles/PeriGame.css
@@ -10,10 +10,5 @@
 
 .construction-icon {
   font-size: 60px;
-  animation: spin 2s linear infinite;
 }
 
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}


### PR DESCRIPTION
## Summary
- change the Peri Game page icon to `faPeopleRoof`
- remove spin animation so the icon stays still

## Testing
- `npm test --silent` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f905ed93c832a8ccf037ebf723695