### PR TITLE
Implement homepage restyle and page updates

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,20 +1,23 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 // import logoCoin from '../images/logo.svg';
-import dexLogo from '../images/dexlogo.png';
 import '../styles/Home.css';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faXTwitter, faTelegramPlane } from '@fortawesome/free-brands-svg-icons';
 import { useTranslation } from 'react-i18next';
 import Paper from '@mui/material/Paper';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 function Home() {
   const [showCopied, setShowCopied] = useState(false);
+  const [fadeOut, setFadeOut] = useState(false);
   const contractAddress = "EdopmgERFJbgJLVTwm9fuvt2Y5DmwjbjdZhVRrM3dpFd";
   const { t } = useTranslation();
+
+  useEffect(() => {
+    const timer = setTimeout(() => setFadeOut(true), 50000);
+    return () => clearTimeout(timer);
+  }, []);
 
   const handleCopyAddress = async () => {
     try {
@@ -36,10 +39,10 @@ function Home() {
       </div> */}
 
       <section className="hero">
-        <Typography variant="subtitle1" className="hero-subtitle">
-          {t('heroSubtitle')}
-        </Typography>
-        <Typography variant="body1" className="intro-message">
+        <Typography
+          variant="body1"
+          className={`intro-message ${fadeOut ? 'fade-out' : ''}`}
+        >
           {t('intro')}
         </Typography>
       </section>
@@ -69,17 +72,6 @@ function Home() {
         >
           {t('buy')}
         </Button>
-        <div className="socials">
-          <a href="https://dexscreener.com/solana/EdopmgERFJbgJLVTwm9fuvt2Y5DmwjbjdZhVRrM3dpFd" target="_blank" rel="noopener noreferrer">
-            <img src={dexLogo} alt="Dexscreener Logo" className="dexlogo" />
-          </a>
-          <a href="https://twitter.com/Perionsol" target="_blank" rel="noopener noreferrer">
-            <FontAwesomeIcon icon={faXTwitter} className="social-icon" />
-          </a>
-          <a href="https://t.me/+rNFvjrSESP0yY2Ix" target="_blank" rel="noopener noreferrer">
-            <FontAwesomeIcon icon={faTelegramPlane} className="social-icon" />
-          </a>
-        </div>
       </div>
     </Container>
   );

--- a/src/pages/Manga.js
+++ b/src/pages/Manga.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import '../styles/Manga.css';
 import { useTranslation } from 'react-i18next';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Button from '@mui/material/Button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPenNib } from '@fortawesome/free-solid-svg-icons';
 
 const Manga = () => {
   const { t } = useTranslation();
@@ -12,12 +11,10 @@ const Manga = () => {
   return (
     <div className="manga-page">
       <h2>{t('manga')}</h2>
-      <Card className="mint-card">
-        <CardContent>
-          <h3>{t('mintTitle')}</h3>
-          <Button variant="contained" className="mint-btn">{t('mint')}</Button>
-        </CardContent>
-      </Card>
+      <div className="manga-loader">
+        <FontAwesomeIcon icon={faPenNib} className="writing-icon" />
+        <span className="typing-text">Writing new chapters...</span>
+      </div>
       <div className="manga-coming-soon">{t('mangaComingSoon')}</div>
     </div>
   );

--- a/src/pages/PeriGame.js
+++ b/src/pages/PeriGame.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPeopleRoof } from '@fortawesome/free-solid-svg-icons';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 import '../styles/PeriGame.css';
 import { useTranslation } from 'react-i18next';
 import Typography from '@mui/material/Typography';
@@ -9,7 +9,7 @@ const PeriGame = () => {
   const { t } = useTranslation();
   return (
     <div className="game-construction">
-      <FontAwesomeIcon icon={faPeopleRoof} className="construction-icon" />
+      <FontAwesomeIcon icon={faSpinner} spin className="construction-icon" />
       <Typography variant="h5">{t('underConstruction')}</Typography>
     </div>
   );

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -6,11 +6,11 @@
     text-align: center;
     padding-bottom: 50px;
     overflow-x: hidden;
-    background-color: #ADD8E6;
+    background: linear-gradient(to bottom, #f0f8ff, #add8e6);
 }
 .hero {
-    padding: 60px 20px 20px;
-    color: #fff;
+    padding: 40px 20px 20px;
+    color: #333;
 }
 
 .hero-title {
@@ -83,15 +83,15 @@
 }
 
 .contract-address {
-    background-color: #ffffff;
-    color: #333;
-    border: 2px solid var(--primary-green);
+    background-color: #FFD700;
+    color: #000;
+    border: 3px solid #ae6b01;
     font-weight: bold;
-    border-radius: 6px;
-    padding: 8px 12px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    border-radius: 8px;
+    padding: 10px 16px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
     margin-bottom: 10px;
-    font-size: 1rem;
+    font-size: 1.2rem;
 }
 
 .intro-message {
@@ -103,6 +103,20 @@
     font-size: 16px;
     line-height: 1.4;
     margin-top: 10px;
+    transition: opacity 3s ease;
+}
+
+.fade-out {
+    animation: fadeOutAnim 3s forwards;
+}
+
+@keyframes fadeOutAnim {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
 }
 
 

--- a/src/styles/Manga.css
+++ b/src/styles/Manga.css
@@ -5,24 +5,38 @@
   font-family: 'Comic Sans MS', 'Comic Neue', cursive;
 }
 
-.mint-card {
-  text-align: center;
-  padding: 20px;
-  margin: 20px auto;
-  max-width: 400px;
-  background-color: var(--sky-blue);
-  border-radius: 8px;
-  border: 4px dotted var(--accent-brown);
+
+.manga-loader {
+  margin-top: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--accent-brown);
+  font-size: 1.5rem;
 }
 
-.mint-title {
-  color: var(--accent-brown);
+.writing-icon {
+  font-size: 50px;
   margin-bottom: 10px;
 }
 
-.mint-btn {
-  background-color: var(--primary-green) !important;
-  color: #fff !important;
+.typing-text {
+  border-right: 2px solid var(--accent-brown);
+  white-space: nowrap;
+  overflow: hidden;
+  animation: typing 2s steps(20, end) infinite,
+             blinkCursor 0.75s step-end infinite;
+}
+
+@keyframes typing {
+  0% { width: 0; }
+  50% { width: 100%; }
+  100% { width: 0; }
+}
+
+@keyframes blinkCursor {
+  from { border-color: transparent; }
+  to { border-color: var(--accent-brown); }
 }
 
 


### PR DESCRIPTION
## Summary
- restyle the home page with gradient background
- fade out hero paragraph after 50 seconds
- highlight contract address and remove social icons
- remove manga minting UI and add writing loader
- change game page icon to a spinning loader

## Testing
- `npm test --silent` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621f573564832a92a9eba29d612200