### PR TITLE
Add audio toggle and global styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@mui/material": "^5.15.8",
     "@mui/icons-material": "^5.15.8",
     "@emotion/react": "^11.11.3",
-    "@emotion/styled": "^11.11.3"
+    "@emotion/styled": "^11.11.3",
+    "react-howler": "^3.2.0"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/src/App.css
+++ b/src/App.css
@@ -10,6 +10,7 @@ html {
   padding: 0;
   font-family: 'Roboto', Arial, sans-serif;
   background-color: var(--sky-blue);
+  font-weight: bold; /* Make text bolder across the page */
 }
 
 

--- a/src/components/AudioToggle.js
+++ b/src/components/AudioToggle.js
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import ReactHowler from 'react-howler';
+import VolumeUpIcon from '@mui/icons-material/VolumeUp';
+import VolumeOffIcon from '@mui/icons-material/VolumeOff';
+import '../styles/AudioToggle.css';
+
+const AudioToggle = () => {
+  const [playing, setPlaying] = useState(false);
+
+  const toggle = () => {
+    setPlaying(p => !p);
+  };
+
+  return (
+    <div className="audio-toggle" onClick={toggle}>
+      {playing ? <VolumeOffIcon /> : <VolumeUpIcon />}
+      <ReactHowler src="/song.mp3" playing={playing} loop volume={0.5} />
+    </div>
+  );
+};
+
+export default AudioToggle;

--- a/src/components/BirdBuyButton.js
+++ b/src/components/BirdBuyButton.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import '../styles/BirdBuyButton.css';
+import { useTranslation } from 'react-i18next';
 
 const BirdBuyButton = () => {
   const [position, setPosition] = useState({ top: '50%', left: '50%' });
@@ -22,13 +23,15 @@ const BirdBuyButton = () => {
       'https://www.pump.fun/EdopmgERFJbgJLVTwm9fuvt2Y5DmwjbjdZhVRrM3dpFd';
   };
 
+  const { t } = useTranslation();
+
   return (
     <button
       className="bird-buy-button"
       style={{ top: position.top, left: position.left }}
       onClick={handleClick}
     >
-      BUY
+      {t('buyBird')}
     </button>
   );
 };

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import i18n from 'i18next';
 import * as Dialog from '@radix-ui/react-dialog';
 import { HamburgerMenuIcon } from '@radix-ui/react-icons';
+import AudioToggle from './AudioToggle';
 
 const Navbar = () => {
   const [open, setOpen] = useState(false);
@@ -28,6 +29,7 @@ const Navbar = () => {
         <button onClick={() => changeLanguage('en')} className="language-button">English</button>
         <button onClick={() => changeLanguage('es')} className="language-button">Español</button>
       </div>
+      <AudioToggle />
 
       <div className="navbar-links desktop-links">
         <ul>

--- a/src/components/WhyPerico.js
+++ b/src/components/WhyPerico.js
@@ -1,37 +1,28 @@
 import React from 'react';
 import '../styles/WhyPerico.css';
+import { useTranslation } from 'react-i18next';
 
 const items = [
-  {
-    emoji: '🕊️',
-    title: 'Soaring Spirit',
-    text: 'Perico spreads his wings across the crypto skies.'
-  },
-  {
-    emoji: '🛫',
-    title: 'Join the Flight',
-    text: 'Hop on board and shout \u201cS\u00e1quenlo!\u201d'
-  },
-  {
-    emoji: '🎉',
-    title: 'Feathered Fun',
-    text: 'Celebrate every pump with style.'
-  }
+  { emoji: '🕊️', key: 'why1' },
+  { emoji: '🛫', key: 'why2' },
+  { emoji: '🎉', key: 'why3' }
 ];
 
-const WhyPerico = () => (
-  <section className="why-perico">
-    <h2>Why Fly with $PERI?</h2>
-    <div className="why-items">
-      {items.map((item, i) => (
-        <div className="why-item" key={i}>
-          <span className="emoji">{item.emoji}</span>
-          <h3>{item.title}</h3>
-          <p>{item.text}</p>
-        </div>
-      ))}
-    </div>
-  </section>
-);
+const WhyPerico = () => {
+  const { t } = useTranslation();
+  return (
+    <section className="why-perico">
+      <h2>{t('whyTitle')}</h2>
+      <div className="why-items">
+        {items.map((item, i) => (
+          <div className="why-item" key={i}>
+            <span className="emoji">{item.emoji}</span>
+            <p>{t(item.key)}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
 
 export default WhyPerico;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -39,9 +39,10 @@
     "generate": "Generate",
     "mintTitle": "Mint Peri Manga NFT",
     "mint": "Mint Now",
-    "whyTitle": "Why Fly with $PERI?",
+    "whyTitle": "S\u00e1quelo!",
     "why1": "Soaring Spirit - Perico spreads his wings across the crypto skies.",
     "why2": "Join the Flight - Hop on board and shout 'S\u00e1quenlo!'",
     "why3": "Feathered Fun - Celebrate every pump with style.",
+    "buyBird": "BUY",
     "underConstruction": "Under Construction"
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -39,9 +39,10 @@
     "generate": "Generar",
     "mintTitle": "Mintear NFT del manga de Peri",
     "mint": "Mintear",
-    "whyTitle": "\u00bfPor qu\u00e9 volar con $PERI?",
+    "whyTitle": "S\u00e1quelo!",
     "why1": "Esp\u00edritu elevado - A Perico le encanta explorar los cielos cripto.",
     "why2": "\u00danete al vuelo - S\u00fabete y grita '¡S\u00e1quenlo!'",
     "why3": "Diversi\u00f3n plum\u00edfera - Celebra cada pump con estilo.",
+    "buyBird": "COMPRAR",
     "underConstruction": "En construcción"
 }

--- a/src/styles/AudioToggle.css
+++ b/src/styles/AudioToggle.css
@@ -1,0 +1,6 @@
+.audio-toggle {
+  cursor: pointer;
+  margin-left: 10px;
+  display: flex;
+  align-items: center;
+}

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -105,11 +105,11 @@
 }
 
 .contract-address {
-    background-color: #FFD700;
+    background-color: rgba(255, 255, 255, 0.8); /* subtle opacity */
     color: #000;
     border: 3px solid #ae6b01;
     font-weight: bold;
-    border-radius: 8px;
+    border-radius: 20px; /* rounded bubble style */
     padding: 10px 16px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
     margin-bottom: 10px;

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -140,3 +140,5 @@
     text-decoration: none;
     color: black;
 }
+
+.audio-toggle svg { color: black; }


### PR DESCRIPTION
## Summary
- make all text bold globally
- style contract address as rounded bubble
- add translation-driven WhyPerico section
- add new AudioToggle component and integrate into Navbar
- update translations and BirdBuyButton text
- include react-howler dependency

## Testing
- `npm test` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_686227b5bdfc832a89af1623460aa0fc