### PR TITLE
Enhance Manga page with mint UI

### DIFF
--- a/src/pages/Manga.js
+++ b/src/pages/Manga.js
@@ -1,20 +1,34 @@
-import React from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPaintBrush } from '@fortawesome/free-solid-svg-icons';
+import React, { useState } from 'react';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import LinearProgress from '@mui/material/LinearProgress';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import { PRIMARY_GREEN } from '../styles/theme';
 
 const Manga = () => {
+  const [message, setMessage] = useState('');
+
+  const handleMint = () => {
+    setMessage('Manga minting is in progress!');
+  };
+
   return (
-    <Box sx={{ p: 2, textAlign: 'center', fontWeight: 'bold' }}>
-      <Box sx={{ mt: 3, display: 'flex', flexDirection: 'column', alignItems: 'center', color: PRIMARY_GREEN, fontSize: '1.5rem' }}>
-        <FontAwesomeIcon icon={faPaintBrush} data-testid="writing-icon" style={{ fontSize: 50, marginBottom: 10, color: PRIMARY_GREEN }} />
-        <svg data-testid="pen-stroke" viewBox="0 0 200 50" style={{ width: 200, height: 50 }}>
-          <path d="M10 30 Q70 5 130 30" fill="none" stroke={PRIMARY_GREEN} strokeWidth="2" strokeDasharray="200" strokeDashoffset="200">
-            <animate attributeName="stroke-dashoffset" from="200" to="0" dur="3s" fill="freeze" />
-          </path>
-        </svg>
-      </Box>
+    <Box sx={{ p: 2, textAlign: 'center' }}>
+      <LinearProgress variant="determinate" value={1} sx={{ height: 8, borderRadius: 5, mb: 2 }} />
+      <Tooltip title="Pay with USDC, SOL, or PERI">
+        <Typography variant="h6" sx={{ fontWeight: 'bold', mt: 2 }} data-testid="price">
+          $2.99
+        </Typography>
+      </Tooltip>
+      <Button variant="contained" onClick={handleMint} sx={{ mt: 2, backgroundColor: PRIMARY_GREEN }}>
+        Mint Manga
+      </Button>
+      {message && (
+        <Typography sx={{ mt: 2 }} data-testid="mint-message">
+          {message}
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/src/pages/Manga.test.js
+++ b/src/pages/Manga.test.js
@@ -1,9 +1,14 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import Manga from './Manga';
 import '../i18n';
 
-test('renders pen icon', () => {
+test('shows progress bar', () => {
   render(<Manga />);
-  const icon = screen.getByTestId('writing-icon');
-  expect(icon).toBeInTheDocument();
+  expect(screen.getByRole('progressbar')).toBeInTheDocument();
+});
+
+test('shows message on mint', () => {
+  render(<Manga />);
+  fireEvent.click(screen.getByRole('button', { name: /mint manga/i }));
+  expect(screen.getByTestId('mint-message')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- remove unused icons and replace with progress bar
- add mint button with tooltip pricing and minted message
- update Manga tests

## Testing
- `npm test --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_687118916c50832a91352fdf9d18a0b9