### PR TITLE
Implement minting status message with bilingual options

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -16,5 +16,10 @@
     "stats.marketCap": "Market Cap",
     "stats.totalSupply": "Total Supply",
     "stats.circulatingSupply": "Circulating Supply",
-    "stats.holders": "Holders"
+    "stats.holders": "Holders",
+    "mintManga": "Mint Manga",
+    "mintEnglish": "Mint English",
+    "mintSpanish": "Mint Spanish",
+    "mintingProgress": "Minting is not possible yet as the manga chapter 1 is in progress.",
+    "mangaTopMessage": "Manga is currently in writing and not mintable."
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -16,5 +16,10 @@
   "stats.marketCap": "Capitalización de mercado",
   "stats.totalSupply": "Suministro total",
   "stats.circulatingSupply": "Suministro circulante",
-  "stats.holders": "Tenedores"
+  "stats.holders": "Tenedores",
+  "mintManga": "Acu\u00f1ar Manga",
+  "mintEnglish": "Acu\u00f1ar en ingl\u00e9s",
+  "mintSpanish": "Acu\u00f1ar en espa\u00f1ol",
+  "mintingProgress": "La acu\u00f1aci\u00f3n no es posible todav\u00eda porque el cap\u00edtulo 1 del manga est\u00e1 en progreso.",
+  "mangaTopMessage": "El manga se est\u00e1 escribiendo y no se puede acu\u00f1ar."
 }

--- a/src/pages/Manga.js
+++ b/src/pages/Manga.js
@@ -5,25 +5,43 @@ import LinearProgress from '@mui/material/LinearProgress';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { PRIMARY_GREEN } from '../styles/theme';
+import { useTranslation } from 'react-i18next';
+import i18n from '../i18n';
 
 const Manga = () => {
+  const { t } = useTranslation();
   const [message, setMessage] = useState('');
+  const [showOptions, setShowOptions] = useState(false);
 
   const handleMint = () => {
-    setMessage('Manga minting is in progress!');
+    setShowOptions(true);
+  };
+
+  const handleSelectLang = (lang) => {
+    setMessage(i18n.t('mintingProgress', { lng: lang }));
+    setShowOptions(false);
   };
 
   return (
     <Box sx={{ p: 2, textAlign: 'center' }}>
+      <Typography sx={{ fontWeight: 'bold', mb: 1 }} data-testid="top-message">
+        {t('mangaTopMessage')}
+      </Typography>
       <LinearProgress variant="determinate" value={1} sx={{ height: 8, borderRadius: 5, mb: 2 }} />
       <Tooltip title="Pay with USDC, SOL, or PERI">
         <Typography variant="h6" sx={{ fontWeight: 'bold', mt: 2 }} data-testid="price">
-          $2.99
+          $0.99
         </Typography>
       </Tooltip>
       <Button variant="contained" onClick={handleMint} sx={{ mt: 2, backgroundColor: PRIMARY_GREEN }}>
-        Mint Manga
+        {t('mintManga')}
       </Button>
+      {showOptions && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2, mt: 2 }}>
+          <Button variant="outlined" onClick={() => handleSelectLang('en')}>{t('mintEnglish')}</Button>
+          <Button variant="outlined" onClick={() => handleSelectLang('es')}>{t('mintSpanish')}</Button>
+        </Box>
+      )}
       {message && (
         <Typography sx={{ mt: 2 }} data-testid="mint-message">
           {message}

--- a/src/pages/Manga.test.js
+++ b/src/pages/Manga.test.js
@@ -7,8 +7,16 @@ test('shows progress bar', () => {
   expect(screen.getByRole('progressbar')).toBeInTheDocument();
 });
 
-test('shows message on mint', () => {
+test('shows language options when mint clicked', () => {
   render(<Manga />);
   fireEvent.click(screen.getByRole('button', { name: /mint manga/i }));
+  expect(screen.getByRole('button', { name: /mint english/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /mint spanish/i })).toBeInTheDocument();
+});
+
+test('shows message after choosing language', () => {
+  render(<Manga />);
+  fireEvent.click(screen.getByRole('button', { name: /mint manga/i }));
+  fireEvent.click(screen.getByRole('button', { name: /mint english/i }));
   expect(screen.getByTestId('mint-message')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update manga mint page to show writing status banner and language options
- change mint price to $0.99
- add translations for new strings in English and Spanish
- update tests for new minting flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68711c5b73e0832a9254c741216c8c1f