### PR TITLE
Fix mobile language controls and contract toast layering

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -32,13 +32,23 @@ const Navbar = () => {
           </Typography>
         </Box>
 
-        <Box sx={{ display: { xs: 'none', md: 'flex' }, gap: 1 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            gap: { xs: 0.5, md: 1 },
+            alignItems: 'center',
+            mr: { xs: 1, md: 0 }
+          }}
+        >
           <Button
             onClick={() => changeLanguage('en')}
             size="small"
             sx={{
               color: 'white',
               textShadow: '1px 1px 2px rgba(0,0,0,0.5)',
+              fontSize: { xs: '0.65rem', sm: '0.75rem', md: '0.8rem' },
+              minWidth: 'auto',
+              px: { xs: 1, sm: 1.5 },
               '&:hover': { border: '2px solid #388e3c' }
             }}
           >
@@ -50,6 +60,9 @@ const Navbar = () => {
             sx={{
               color: 'white',
               textShadow: '1px 1px 2px rgba(0,0,0,0.5)',
+              fontSize: { xs: '0.65rem', sm: '0.75rem', md: '0.8rem' },
+              minWidth: 'auto',
+              px: { xs: 1, sm: 1.5 },
               '&:hover': { border: '2px solid #388e3c' }
             }}
           >
@@ -86,7 +99,41 @@ const Navbar = () => {
           <Dialog.Portal>
             <Dialog.Overlay style={{ backgroundColor: 'rgba(0,0,0,0.4)', position: 'fixed', inset: 0, zIndex: 1200 }} />
             <Dialog.Content style={{ backgroundColor: PRIMARY_GREEN, position: 'fixed', top: 0, left: 0, height: '100%', width: '200px', padding: '20px', zIndex: 1201 }}>
-            <Box component="ul" sx={{ listStyle: 'none', p: 0, m: 0, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+                <Button
+                  onClick={() => {
+                    changeLanguage('en');
+                    setOpen(false);
+                  }}
+                  size="small"
+                  sx={{
+                    color: 'white',
+                    textShadow: '1px 1px 2px rgba(0,0,0,0.5)',
+                    minWidth: 'auto',
+                    px: 1.5,
+                    '&:hover': { border: '2px solid #388e3c' }
+                  }}
+                >
+                  English
+                </Button>
+                <Button
+                  onClick={() => {
+                    changeLanguage('es');
+                    setOpen(false);
+                  }}
+                  size="small"
+                  sx={{
+                    color: 'white',
+                    textShadow: '1px 1px 2px rgba(0,0,0,0.5)',
+                    minWidth: 'auto',
+                    px: 1.5,
+                    '&:hover': { border: '2px solid #388e3c' }
+                  }}
+                >
+                  Español
+                </Button>
+              </Box>
+              <Box component="ul" sx={{ listStyle: 'none', p: 0, m: 0, display: 'flex', flexDirection: 'column', gap: 1 }}>
                 <li><Button component={Link} to="/" onClick={() => setOpen(false)} sx={{ color: 'white', '&:hover': { border: '2px solid #388e3c' } }}>{t('home')}</Button></li>
                 <li><Button component={Link} to="/manga" onClick={() => setOpen(false)} sx={{ color: 'white', '&:hover': { border: '2px solid #388e3c' } }}>{t('manga')}</Button></li>
                 <li>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -138,7 +138,13 @@ function Home() {
               <Typography
                 variant="body1"
                 sx={{
-                  fontSize: { xs: '0.95rem', sm: '1.25rem' },
+                  fontSize: { xs: '0.7rem', sm: '0.95rem', md: '1.25rem' },
+                  '@media (max-width:700px)': {
+                    fontSize: '0.85rem'
+                  },
+                  '@media (max-width:500px)': {
+                    fontSize: '0.7rem'
+                  },
                   wordBreak: 'break-all',
                   textAlign: { xs: 'center', sm: 'left' }
                 }}
@@ -227,7 +233,7 @@ function Home() {
         </Box>
       </Box>
       {showCopied && (
-        <Box sx={{ position: 'fixed', bottom: 20, right: 20, backgroundColor: PRIMARY_GREEN, color: 'white', p: 1.5, borderRadius: 1, boxShadow: '0 2px 6px rgba(0,0,0,0.3)' }}>
+        <Box sx={{ position: 'fixed', bottom: 20, right: 20, backgroundColor: PRIMARY_GREEN, color: 'white', p: 1.5, borderRadius: 1, boxShadow: '0 2px 6px rgba(0,0,0,0.3)', zIndex: 2000 }}>
           {t('contractcopied')}
         </Box>
       )}


### PR DESCRIPTION
## Summary
- ensure the language toggle buttons are visible on mobile and accessible inside the drawer menu
- reduce the contract address typography size on small screens for better fit
- place the copied contract toast above other UI layers so it is never hidden

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e09424bdec832a9584aab63e51973b